### PR TITLE
Fix: Release Artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,9 +247,6 @@ jobs:
             sha256sum "$file" >> checksums.txt
           fi
         done
-        
-        # Move all archives to root level
-        find . -name "*.tar.gz" -o -name "*.zip" -exec mv {} . \;
 
     - name: Create Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: [test, lint]
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
     strategy:
       matrix:
         goos: [linux, darwin, windows]
@@ -166,7 +166,7 @@ jobs:
     name: Generate SBOM
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
     permissions:
       security-events: write
       contents: read
@@ -217,7 +217,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [test, lint, build, sbom, security]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    #if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: artifacts
+        merge-multiple: true
 
     - name: Generate version
       id: version
@@ -257,8 +258,8 @@ jobs:
         prerelease: false
         generate_release_notes: true
         files: |
-          artifacts/*.tar.gz
-          artifacts/*.zip
+          artifacts/**/*.tar.gz
+          artifacts/**/*.zip
           artifacts/checksums.txt
           artifacts/sbom-reports/*
         body: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
           artifacts/**/*.tar.gz
           artifacts/**/*.zip
           artifacts/checksums.txt
-          artifacts/sbom-reports/*
+          artifacts/sbom.spdx.json
         body: |
           ## SpecGate Release ${{ steps.version.outputs.version }}
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: [test, lint]
-    #if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     strategy:
       matrix:
         goos: [linux, darwin, windows]
@@ -166,7 +166,7 @@ jobs:
     name: Generate SBOM
     runs-on: ubuntu-latest
     needs: [build]
-    #if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     permissions:
       security-events: write
       contents: read
@@ -217,7 +217,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [test, lint, build, sbom, security]
-    #if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Pull Request Summary

### What
This PR fixes the issue of certain release artifacts (like .tar.gz files) not appearing in any built releases.

### Why
All releases should include compiled binaries for all platforms.

### How
The issue was that the download-artifacts@v4 action used individual subdirectories to serve artifacts, instead of downloading into one directory. It has now been flattened.

### Testing
<!-- How you tested the changes -->
- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing completed
- [x] Tested with sample OpenAPI spec
- [x] Verified logging output

### Breaking Changes
<!-- Any breaking changes (if applicable) -->
- [x] No breaking changes
- [ ] Breaking changes (please describe below)

<!-- If breaking changes, describe them here -->

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding standards
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My changes don't break existing functionality
- [x] I have tested my changes locally