### PR TITLE
docs(main): output usage when no args provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A lightweight OpenAPI validation proxy that validates HTTP responses against Ope
 
 ## Features
 
-- **Real-time validation** of HTTP responses against OpenAPI 3.x and Swagger 2.0 specifications
+- **Real-time validation** of HTTP responses against OpenAPI 3.0 and 2.0 specifications
 - **Remote spec loading** from HTTP/HTTPS URLs with safety warnings
 - **Multiple validation modes**: strict, warn, report
 - **Colored logging** with timestamps and structured output
@@ -15,11 +15,7 @@ A lightweight OpenAPI validation proxy that validates HTTP responses against Ope
 
 ### Download Binary
 
-```bash
-# Download the latest release
-curl -L https://github.com/sorenjohanson/specgate/releases/latest/download/specgate -o specgate
-chmod +x specgate
-```
+Navigate to the [Releases](https://github.com/sorenjohanson/specgate/releases) page and download the package appropriate for your OS. Unpack the included `specgate` binary anywhere you like.
 
 ### Build from Source
 

--- a/main.go
+++ b/main.go
@@ -39,6 +39,12 @@ func main() {
 	)
 	flag.Parse()
 
+	// Show help if no arguments provided
+	if len(os.Args) == 1 {
+		flag.Usage()
+		return
+	}
+
 	// GPL required copyright notice
 	fmt.Println("SpecGate Copyright (C) 2025 Søren Johanson")
 	fmt.Println("This program comes with ABSOLUTELY NO WARRANTY.")

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestValidateSpecUpstreamMatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		specURL     string
+		upstreamURL string
+		expectError bool
+	}{
+		{
+			name:        "matching URLs",
+			specURL:     "https://api.example.com/spec.yaml",
+			upstreamURL: "https://api.example.com",
+			expectError: false,
+		},
+		{
+			name:        "matching URLs with different paths",
+			specURL:     "https://api.example.com/v1/spec.yaml",
+			upstreamURL: "https://api.example.com/v2",
+			expectError: false,
+		},
+		{
+			name:        "different schemes",
+			specURL:     "http://api.example.com/spec.yaml",
+			upstreamURL: "https://api.example.com",
+			expectError: true,
+		},
+		{
+			name:        "different hosts",
+			specURL:     "https://api1.example.com/spec.yaml",
+			upstreamURL: "https://api2.example.com",
+			expectError: true,
+		},
+		{
+			name:        "different ports",
+			specURL:     "https://api.example.com:8080/spec.yaml",
+			upstreamURL: "https://api.example.com:9090",
+			expectError: true,
+		},
+		{
+			name:        "invalid spec URL",
+			specURL:     "://invalid-url",
+			upstreamURL: "https://api.example.com",
+			expectError: true,
+		},
+		{
+			name:        "invalid upstream URL",
+			specURL:     "https://api.example.com/spec.yaml",
+			upstreamURL: "://invalid-url",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSpecUpstreamMatch(tt.specURL, tt.upstreamURL)
+			if (err != nil) != tt.expectError {
+				t.Errorf("validateSpecUpstreamMatch() error = %v, expectError %v", err, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestMainShowsUsageWithNoArgs(t *testing.T) {
+	oldArgs := os.Args
+
+	os.Args = []string{"specgate"}
+
+	defer func() {
+		os.Args = oldArgs
+	}()
+
+	fs := flag.NewFlagSet("specgate", flag.ContinueOnError)
+	var buf bytes.Buffer
+	fs.SetOutput(&buf)
+
+	testMainLogicWithFlagSet(t, fs, &buf)
+}
+
+func testMainLogicWithFlagSet(t *testing.T, fs *flag.FlagSet, buf *bytes.Buffer) {
+	fs.String("spec", "openapi.yaml", "Path to OpenAPI spec")
+	fs.String("upstream", "http://localhost:3000", "Upstream API URL")
+	fs.String("port", "8080", "Proxy port")
+	fs.String("mode", "warn", "Mode: strict|warn|report")
+
+	err := fs.Parse([]string{})
+	if err != nil {
+		t.Fatalf("Failed to parse flags: %v", err)
+	}
+
+	if len(os.Args) == 1 {
+		fs.Usage()
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Usage of") {
+		t.Errorf("Expected usage output when no args provided, got: %q", output)
+	}
+	if !strings.Contains(output, "-spec") {
+		t.Errorf("Expected -spec flag in usage output, got: %q", output)
+	}
+	if !strings.Contains(output, "-upstream") {
+		t.Errorf("Expected -upstream flag in usage output, got: %q", output)
+	}
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestParseMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    Mode
+		expectError bool
+	}{
+		{
+			name:        "strict mode",
+			input:       "strict",
+			expected:    ModeStrict,
+			expectError: false,
+		},
+		{
+			name:        "warn mode",
+			input:       "warn",
+			expected:    ModeWarn,
+			expectError: false,
+		},
+		{
+			name:        "report mode",
+			input:       "report",
+			expected:    ModeReport,
+			expectError: false,
+		},
+		{
+			name:        "uppercase input",
+			input:       "STRICT",
+			expected:    ModeStrict,
+			expectError: false,
+		},
+		{
+			name:        "mixed case input",
+			input:       "WaRn",
+			expected:    ModeWarn,
+			expectError: false,
+		},
+		{
+			name:        "invalid mode",
+			input:       "invalid",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "empty mode",
+			input:       "",
+			expected:    "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseMode(tt.input)
+			if (err != nil) != tt.expectError {
+				t.Errorf("parseMode() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("parseMode() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsUndocumentedEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "no matching operation",
+			err:      errors.New("no matching operation found"),
+			expected: true,
+		},
+		{
+			name:     "path not found",
+			err:      errors.New("path not found"),
+			expected: true,
+		},
+		{
+			name:     "operation not found",
+			err:      errors.New("operation not found"),
+			expected: true,
+		},
+		{
+			name:     "case insensitive match",
+			err:      errors.New("No Route Found"),
+			expected: true,
+		},
+		{
+			name:     "unrelated error",
+			err:      errors.New("connection refused"),
+			expected: false,
+		},
+		{
+			name:     "empty error message",
+			err:      errors.New(""),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isUndocumentedEndpoint(tt.err)
+			if result != tt.expected {
+				t.Errorf("isUndocumentedEndpoint() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidatingProxy_ReadResponseBody(t *testing.T) {
+	tests := []struct {
+		name          string
+		contentLength string
+		bodySize      int
+		expectSkipped bool
+	}{
+		{
+			name:          "small response",
+			contentLength: "100",
+			bodySize:      100,
+			expectSkipped: false,
+		},
+		{
+			name:          "large content-length header",
+			contentLength: "20971520", // 20MB
+			bodySize:      0,
+			expectSkipped: true,
+		},
+		{
+			name:          "no content-length but large body",
+			contentLength: "",
+			bodySize:      20971520, // 20MB
+			expectSkipped: true,
+		},
+		{
+			name:          "exactly at limit",
+			contentLength: "10485760", // 10MB
+			bodySize:      10485760,
+			expectSkipped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := make([]byte, tt.bodySize)
+			for i := range body {
+				body[i] = 'a'
+			}
+
+			resp := &http.Response{
+				Header: make(http.Header),
+				Body:   io.NopCloser(bytes.NewReader(body)),
+			}
+
+			if tt.contentLength != "" {
+				resp.Header.Set("Content-Length", tt.contentLength)
+			}
+
+			vp := &ValidatingProxy{
+				logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+			}
+
+			result, err := vp.readResponseBody(resp)
+
+			if err != nil {
+				t.Errorf("readResponseBody() unexpected error: %v", err)
+				return
+			}
+
+			if tt.expectSkipped {
+				if result != nil {
+					t.Errorf("readResponseBody() expected nil for large response, got %d bytes", len(result))
+				}
+			} else {
+				if result == nil {
+					t.Errorf("readResponseBody() expected body data, got nil")
+				} else if len(result) != tt.bodySize {
+					t.Errorf("readResponseBody() expected %d bytes, got %d", tt.bodySize, len(result))
+				}
+			}
+		})
+	}
+}
+
+func TestValidatingProxy_ReplaceResponseWithError(t *testing.T) {
+	resp := &http.Response{
+		Header:     make(http.Header),
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(`{"original": "data"}`)),
+	}
+	resp.Header.Set("Content-Type", "application/json")
+	resp.Header.Set("Content-Encoding", "gzip")
+	resp.Header.Set("ETag", "123456")
+
+	vp := &ValidatingProxy{}
+	testErr := errors.New("test validation error")
+
+	vp.replaceResponseWithError(resp, testErr)
+
+	if resp.StatusCode != 500 {
+		t.Errorf("replaceResponseWithError() status code = %d, expected 500", resp.StatusCode)
+	}
+
+	if resp.Header.Get("Content-Type") != "application/json" {
+		t.Errorf("replaceResponseWithError() content-type = %q, expected application/json", resp.Header.Get("Content-Type"))
+	}
+
+	if resp.Header.Get("Content-Encoding") != "" {
+		t.Errorf("replaceResponseWithError() should have removed Content-Encoding header")
+	}
+	if resp.Header.Get("ETag") != "" {
+		t.Errorf("replaceResponseWithError() should have removed ETag header")
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("replaceResponseWithError() failed to read body: %v", err)
+		return
+	}
+
+	if !strings.Contains(string(bodyBytes), "Response validation failed") {
+		t.Errorf("replaceResponseWithError() body should contain error message")
+	}
+	if !strings.Contains(string(bodyBytes), "test validation error") {
+		t.Errorf("replaceResponseWithError() body should contain validation error details")
+	}
+
+	expectedLength := len(bodyBytes)
+	actualLength, _ := strconv.Atoi(resp.Header.Get("Content-Length"))
+	if actualLength != expectedLength {
+		t.Errorf("replaceResponseWithError() content-length = %d, expected %d", actualLength, expectedLength)
+	}
+}


### PR DESCRIPTION
## Pull Request Summary

### What
This commit outputs -h usage when no args are provided to the binary. It also updates the README to reflect the proper installation process.

### Why
Currently, it outputs an error when no args are provided because it simply falls back to default values.

### How
Just output `flag.Usage()` if no args are provided.

### Testing
<!-- How you tested the changes -->
- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing completed
- [x] Tested with sample OpenAPI spec
- [x] Verified logging output

### Breaking Changes
<!-- Any breaking changes (if applicable) -->
- [x] No breaking changes
- [ ] Breaking changes (please describe below)

<!-- If breaking changes, describe them here -->

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding standards
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My changes don't break existing functionality
- [x] I have tested my changes locally

## Related Issues

Closes #<!-- issue number -->

## Additional Context

<!-- Any additional information, screenshots, or context that would be helpful for reviewers -->